### PR TITLE
Use mpi mutex & Add activate/deactivate scripts

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,7 +11,6 @@ jobs:
       win_64_:
         CONFIG: win_64_
         UPLOAD_PACKAGES: 'True'
-    maxParallel: 4
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
@@ -53,7 +52,7 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=3 pip' # Optional
+        packageSpecs: 'python=3.6 conda-build conda "conda-forge-ci-setup=3" pip' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment

--- a/README.md
+++ b/README.md
@@ -5,9 +5,13 @@ Home: https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi
 
 Package license: MIT
 
-Feedstock license: BSD-3-Clause
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/msmpi-feedstock/blob/master/LICENSE.txt)
 
 Summary: Microsoft message-passing-interface (MS-MPI)
+
+Development: https://github.com/microsoft/Microsoft-MPI
+
+Documentation: https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi
 
 Microsoft MPI (MS-MPI) is a Microsoft implementation of the Message Passing Interface standard for developing and running parallel applications on the Windows platform.
 

--- a/build-locally.py
+++ b/build-locally.py
@@ -12,6 +12,10 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    if ns.debug:
+        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
+        if ns.output_id:
+            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
 
 
 def run_docker_build(ns):
@@ -51,6 +55,14 @@ def verify_config(ns):
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Setup debug environment using `conda debug`",
+    )
+    p.add_argument(
+        "--output-id", help="If running debug, specify the output to setup."
+    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,0 +1,16 @@
+@echo on
+
+:: Backup environment variables (only if the variables are set)
+if defined MSMPI_BIN (
+    set "MSMPI_BIN_CONDA_BACKUP=%MSMPI_BIN%"
+)
+if defined MSMPI_INC (
+    set "MSMPI_INC_CONDA_BACKUP=%MSMPI_INC%"
+)
+if defined MSMPI_LIB64 (
+    set "MSMPI_LIB64_CONDA_BACKUP=%MSMPI_LIB64%"
+)
+
+set MSMPI_BIN=%LIBRARY_BIN%
+set MSMPI_INC=%LIBRARY_INC%
+set MSMPI_LIB64=%LIBRARY_LIB%

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,7 +1,5 @@
 @echo on
 
-echo activate script is called
-
 :: Backup environment variables (only if the variables are set)
 if defined MSMPI_BIN (
     set "MSMPI_BIN_CONDA_BACKUP=%MSMPI_BIN%"

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,5 +1,7 @@
 @echo on
 
+echo activate script is called
+
 :: Backup environment variables (only if the variables are set)
 if defined MSMPI_BIN (
     set "MSMPI_BIN_CONDA_BACKUP=%MSMPI_BIN%"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -26,8 +26,6 @@ setlocal EnableDelayedExpansion
 for %%F in (activate deactivate) DO (
     if not exist %PREFIX%\etc\conda\%%F.d mkdir %PREFIX%\etc\conda\%%F.d
     copy %RECIPE_DIR%\%%F.bat %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
-    :: Copy unix shell activation scripts, needed by Windows Bash users
-    copy %RECIPE_DIR%\%%F.sh %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.sh
 )
 
 dir /s /b

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -19,4 +19,15 @@ if "%ARCH%"=="32" (
     copy %SRC_DIR%\out\Release-x64\bin\sdk\inc\x64\mpifptr.h %LIBRARY_INC%\mpifptr.h
 )
 
+setlocal EnableDelayedExpansion
+
+:: Copy the [de]activate scripts to %PREFIX%\etc\conda\[de]activate.d.
+:: This will allow them to be run on environment activation.
+for %%F in (activate deactivate) DO (
+    if not exist %PREFIX%\etc\conda\%%F.d mkdir %PREFIX%\etc\conda\%%F.d
+    copy %RECIPE_DIR%\%%F.bat %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
+    :: Copy unix shell activation scripts, needed by Windows Bash users
+    copy %RECIPE_DIR%\%%F.sh %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.sh
+)
+
 dir /s /b

--- a/recipe/deactivate.bat
+++ b/recipe/deactivate.bat
@@ -1,0 +1,20 @@
+if not "%MSMPI_BIN_CONDA_BACKUP%"=="" (
+    set "MSMPI_BIN=%MSMPI_BIN_CONDA_BACKUP%"
+    set "MSMPI_BIN_CONDA_BACKUP="
+) else (
+    set "MSMPI_BIN="
+}
+
+if not "%MSMPI_INC_CONDA_BACKUP%"=="" (
+    set "MSMPI_INC=%MSMPI_INC_CONDA_BACKUP%"
+    set "MSMPI_INC_CONDA_BACKUP="
+) else (
+    set "MSMPI_INC="
+)
+
+if not "%MSMPI_LIB64_CONDA_BACKUP%"=="" (
+    set "MSMPI_LIB64=%MSMPI_LIB64_CONDA_BACKUP%"
+    set "MSMPI_LIB64_CONDA_BACKUP="
+) else (
+    set "MSMPI_LIB64="
+)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - conda-build.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,9 @@ test:
     - if not exist %LIBRARY_INC%\\mpi.h exit 1  # [win]
     - if not exist %LIBRARY_LIB%\\msmpi.lib exit 1  # [win]
     - if not exist %LIBRARY_LIB%\\mpifort.lib exit 1  # [win]
+    - if not %MSMPI_BIN% == %LIBRARY_BIN% exit 1  # [win]
+    - if not %MSMPI_INC% == %LIBRARY_INC% exit 1  # [win]
+    - if not %MSMPI_LIB64% == %LIBRARY_LIB% exit 1  # [win]
 
 about:
   home: https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,8 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
     - {{ compiler('m2w64_fortran') }}
+  run:
+    - mpi 1.0 msmpi
 
 test:
   commands:


### PR DESCRIPTION
~~Blocked by https://github.com/conda-forge/mpi-feedstock/pull/7.~~ **UPDATE:** it's in.
Context: https://github.com/conda-forge/mpi4py-feedstock/pull/33#issuecomment-754892876.

I also added activate/deactivate scripts because after installation MS-MPI would set those variables for MPI applications to use. For example, [`FindMPI.cmake`](https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/FindMPI.cmake) and mpi4py would pick up those env variables.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
