### PR TITLE
Fix line ending

### DIFF
--- a/recipe/MSMPI_VER.diff
+++ b/recipe/MSMPI_VER.diff
@@ -1,11 +1,11 @@
-68a69,76
+68a69,78
 > // Patched for Conda-Forge: We cannot touch the Windows Registry, which is the only
 > // way to correctly inform the value in MS-MPI's design, so we circumvent it by
 > // hard-wiring the version value here. See
 > // https://github.com/microsoft/Microsoft-MPI/blob/7ff6bdcdb1d5dc7b791e47457ee2686cd6b3d355/src/mpi.props#L15
 > // https://github.com/mpi4py/mpi4py/blob/18f16da45eaaacfba4cc0293964e1a6548d4c6a6/conf/mpiconfig.py#L194
 > // for how MSMPI_VER should be calculated.
->
+> 
 > // for v10.1.x
 > #define MSMPI_VER 0xA01
 > 

--- a/recipe/MSMPI_VER.diff
+++ b/recipe/MSMPI_VER.diff
@@ -5,5 +5,7 @@
 > // https://github.com/microsoft/Microsoft-MPI/blob/7ff6bdcdb1d5dc7b791e47457ee2686cd6b3d355/src/mpi.props#L15
 > // https://github.com/mpi4py/mpi4py/blob/18f16da45eaaacfba4cc0293964e1a6548d4c6a6/conf/mpiconfig.py#L194
 > // for how MSMPI_VER should be calculated.
-> #define MSMPI_VER 0xA01  // for v10.1.x
+>
+> // for v10.1.x
+> #define MSMPI_VER 0xA01
 > 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -69,7 +69,8 @@ for %%F in (activate deactivate) DO (
 )
 
 echo "patching mpi.h..."
-patch "%LIBRARY_INC%\mpi.h" "%RECIPE_DIR%\MSMPI_VER.diff" || exit 1
+:: add --binary to handle the CRLF line ending
+patch --binary "%LIBRARY_INC%\mpi.h" "%RECIPE_DIR%\MSMPI_VER.diff" || exit 1
 copy "%RECIPE_DIR%\tests\*" .\Tests || exit 1
 
 echo "checking source dir..."

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     sha256: c305ce3f05d142d519f8dd800d83a4b894fc31bcad30512cefb557feaccbe8b4
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not win]
 
 requirements:


### PR DESCRIPTION
1. Fix the line ending in the patch to CRLF
2. Remove the tailing comment in the macro

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
