### PR TITLE
Use installer outputs & Fix (de)activate scripts

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,3 +1,4 @@
+@echo off
 if defined CONDA_BUILD_STATE (
     @echo on
 )

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -2,9 +2,9 @@
 if defined CONDA_BUILD_STATE (
     @echo on
 
-    :: We should ensure the pre-installed MS-MPI v7 is erased
-    :: so that downstream packages do not need to worry about
-    :: how to run MPI tests.
+    rem We should ensure the pre-installed MS-MPI v7 is erased
+    rem so that downstream packages do not need to worry about
+    rem how to run MPI tests.
     if not "%PKG_NAME%"=="msmpi" (
       echo "remove MPI from the image..."
       wmic product where name="Microsoft MPI (7.1.12437.25)" call uninstall || exit 1

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,6 +1,16 @@
 @echo off
 if defined CONDA_BUILD_STATE (
     @echo on
+
+    :: We should ensure the pre-installed MS-MPI v7 is erased
+    :: so that downstream packages do not need to worry about
+    :: how to run MPI tests.
+    if not "%PKG_NAME%"=="msmpi" (
+      echo "remove MPI from the image..."
+      wmic product where name="Microsoft MPI (7.1.12437.25)" call uninstall || exit 1
+      del /f /q "C:\Windows\System32\msmpi.dll" || exit 1
+      del /f /q "C:\Windows\System32\msmpires.dll" || exit 1
+    )
 )
 
 :: Backup environment variables (only if the variables are set)

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,8 +9,8 @@ if not exist %LIBRARY_INC% mkdir %LIBRARY_INC% || exit 1
 :: installer to force updating it for testing...
 :: echo "check installed programs..."
 :: wmic product get name  || exit 1
-:: echo "remove MPI from the image..."
-:: wmic product where name="Microsoft MPI (7.1.12437.25)" call uninstall || exit 1
+echo "remove MPI from the image..."
+wmic product where name="Microsoft MPI (7.1.12437.25)" call uninstall || exit 1
 
 echo "check pwd..."
 dir /s /b
@@ -36,22 +36,20 @@ rmdir /q /s temp || exit 1
 mkdir temp
 mkdir Tests
 echo "Installing MS-MPI Runtime..."
-:: this does not work because it insists on installing to C:\Program Files\Microsoft MPI\, not to our custom path;
-:: however, we still need this to overwrite the vm image's built-in installation so that we can run tests
+:: this installs to C:\Program Files\Microsoft MPI\ instead of to our custom path (-installroot);
+:: however, we still need this to
+:: 1. overwrite the vm image's built-in installation so that we can run tests
+:: 2. generate the correct dlls (yes, the installer would write to the dlls!)
 "%cd%\msmpisetup.exe" -unattend -force -full -installroot "%cd%\temp" -verbose -log "%cd%\log.txt" || exit 1
 echo "printing log..."
 type "%cd%\log.txt" || exit 1
 del log.txt || exit 1
-:: this extraction does the real work for the purpose of packaging
-7z x msmpisetup.exe -o"%cd%\temp" || exit 1
 
-move "%cd%\temp\*.dll" %LIBRARY_BIN% || exit 1
-move "%cd%\temp\mpiexec.exe" %LIBRARY_BIN% || exit 1
-move "%cd%\temp\mpitrace.man" %LIBRARY_BIN% || exit 1
-move "%cd%\temp\msmpilaunchsvc.exe" %LIBRARY_BIN% || exit 1
-move "%cd%\temp\smpd.exe" %LIBRARY_BIN% || exit 1
-move "%cd%\temp\*.exe" "%cd%\Tests" || exit 1
-move "%cd%\temp\*" "%cd%\License" || exit 1
+move "C:\Windows\System32\msmpi.dll" %LIBRARY_BIN% || exit 1
+move "C:\Windows\System32\msmpires.dll" %LIBRARY_BIN% || exit 1
+move "C:\Program Files\Microsoft MPI\Bin\*" %LIBRARY_BIN% || exit 1
+move "C:\Program Files\Microsoft MPI\Benchmarks\*" "%cd%\Tests" || exit 1
+move "C:\Program Files\Microsoft MPI\License\*" "%cd%\License" || exit 1
 
 echo "checking installroot..."
 dir /s /b "%cd%\temp"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -47,6 +47,7 @@ del log.txt || exit 1
 
 move "C:\Windows\System32\msmpi.dll" %LIBRARY_BIN% || exit 1
 move "C:\Windows\System32\msmpires.dll" %LIBRARY_BIN% || exit 1
+dir "C:\Program Files\Microsoft MPI\" || exit 1
 move "C:\Program Files\Microsoft MPI\Bin\*" %LIBRARY_BIN% || exit 1
 move "C:\Program Files\Microsoft MPI\Benchmarks\*" "%cd%\Tests" || exit 1
 move "C:\Program Files\Microsoft MPI\License\*" "%cd%\License" || exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -52,6 +52,7 @@ rmdir "%PREFIX%\Library\License" || exit 1
 echo "checking License..."
 dir /s /b "%cd%\License"
 echo "checking Tests..."
+copy "%RECIPE_DIR%\tests\*" .\Tests || exit 1
 dir /s /b "%cd%\Tests"
 
 echo "copy the [de]activate scripts..."
@@ -63,7 +64,6 @@ for %%F in (activate deactivate) DO (
 echo "patching mpi.h..."
 :: add --binary to handle the CRLF line ending
 patch --binary "%LIBRARY_INC%\mpi.h" "%RECIPE_DIR%\MSMPI_VER.diff" || exit 1
-copy "%RECIPE_DIR%\tests\*" .\Tests || exit 1
 
 echo "checking source dir..."
 dir /s /b

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -47,6 +47,7 @@ move "%PREFIX%\Library\Benchmarks\*" "%cd%\Tests" || exit 1
 rmdir "%PREFIX%\Library\Benchmarks" || exit 1
 move "%PREFIX%\Library\License\*" "%cd%\License" || exit 1
 rmdir "%PREFIX%\Library\License" || exit 1
+rmdir /s /q "%PREFIX%\Library\Redist" || exit 1
 
 :: note: conda-build would copy the two folders below for us
 echo "checking License..."

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,8 +5,8 @@ if not exist %LIBRARY_LIB% mkdir %LIBRARY_LIB% || exit 1
 if not exist %LIBRARY_INC% mkdir %LIBRARY_INC% || exit 1
 
 :: Even if we do this it still doesn't help to fix the PMP version mismatch error
-:: (https://github.com/conda-forge/msmpi-feedstock/issues/2), so we rely on the
-:: installer to force updating it for testing...
+:: (https://github.com/conda-forge/msmpi-feedstock/issues/2). But, this will make
+:: -installroot work later!
 :: echo "check installed programs..."
 :: wmic product get name  || exit 1
 echo "remove MPI from the image..."
@@ -17,6 +17,7 @@ dir /s /b
 
 mkdir temp
 mkdir License
+mkdir Tests
 echo "Installing MS-MPI SDK..."
 :: note: it has to be /a, not /i
 msiexec.exe /quiet /qn /a "%cd%\msmpisdk.msi" TARGETDIR="%cd%\temp" || exit 1
@@ -33,28 +34,20 @@ echo "check target dir..."
 dir /s /b "%cd%\temp"
 rmdir /q /s temp || exit 1
 
-mkdir temp
-mkdir Tests
 echo "Installing MS-MPI Runtime..."
-:: this installs to C:\Program Files\Microsoft MPI\ instead of to our custom path (-installroot);
-:: however, we still need this to
-:: 1. overwrite the vm image's built-in installation so that we can run tests
-:: 2. generate the correct dlls (yes, the installer would write to the dlls!)
-"%cd%\msmpisetup.exe" -unattend -force -full -installroot "%cd%\temp" -verbose -log "%cd%\log.txt" || exit 1
+:: We must run (not extract!) the installer to generate the correct dlls (yes, it would write to the dlls!)
+"%cd%\msmpisetup.exe" -unattend -force -full -installroot "%PREFIX%\Library" -verbose -log "%cd%\log.txt" || exit 1
 echo "printing log..."
 type "%cd%\log.txt" || exit 1
 del log.txt || exit 1
 
 move "C:\Windows\System32\msmpi.dll" %LIBRARY_BIN% || exit 1
 move "C:\Windows\System32\msmpires.dll" %LIBRARY_BIN% || exit 1
-dir "C:\Program Files\Microsoft MPI\" || exit 1
-move "C:\Program Files\Microsoft MPI\Bin\*" %LIBRARY_BIN% || exit 1
-move "C:\Program Files\Microsoft MPI\Benchmarks\*" "%cd%\Tests" || exit 1
-move "C:\Program Files\Microsoft MPI\License\*" "%cd%\License" || exit 1
+move "%PREFIX%\Library\Benchmarks\*" "%cd%\Tests" || exit 1
+rmdir "%PREFIX%\Library\Benchmarks" || exit 1
+move "%PREFIX%\Library\License\*" "%cd%\License" || exit 1
+rmdir "%PREFIX%\Library\License" || exit 1
 
-echo "checking installroot..."
-dir /s /b "%cd%\temp"
-rmdir "%cd%\temp" || exit 1
 :: note: conda-build would copy the two folders below for us
 echo "checking License..."
 dir /s /b "%cd%\License"

--- a/recipe/deactivate.bat
+++ b/recipe/deactivate.bat
@@ -1,3 +1,8 @@
+@echo off
+if defined CONDA_BUILD_STATE (
+    @echo on
+)
+
 if not "%MSMPI_BIN_CONDA_BACKUP%"=="" (
     set "MSMPI_BIN=%MSMPI_BIN_CONDA_BACKUP%"
     set "MSMPI_BIN_CONDA_BACKUP="

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -84,9 +84,9 @@ about:
   license: MIT
   license_file:
     - License\MicrosoftMPI-SDK-EULA.rtf
-    - License\MicrosoftMPI_Redistributable_EULA.rtf
+    - License\MicrosoftMPI-Redistributable-EULA.rtf
     - License\MPI-SDK-TPN.txt
-    - License\MPI_Redistributables_TPN.txt
+    - License\MPI-Redistributables-TPN.txt
   summary: Microsoft message-passing-interface (MS-MPI)
   description: |
     Microsoft MPI (MS-MPI) is a Microsoft implementation of the Message Passing

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     sha256: c305ce3f05d142d519f8dd800d83a4b894fc31bcad30512cefb557feaccbe8b4
 
 build:
-  number: 1
+  number: 2
   skip: true  # [not win]
 
 requirements:
@@ -27,8 +27,6 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('m2w64_fortran') }}
     - m2-patch
-  host:
-    - 7zip
   run:
     - mpi 1.0 msmpi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ test:
   commands:
     # simple package integraty check
     - if not exist %LIBRARY_BIN%\\mpiexec.exe exit 1  # [win]
+    - if not exist %LIBRARY_BIN%\\smpd.exe exit 1  # [win]
     - if not exist %LIBRARY_BIN%\\msmpi.dll exit 1  # [win]
     - if not exist %LIBRARY_INC%\\mpi.f90 exit 1  # [win]
     - if not exist %LIBRARY_INC%\\mpi.h exit 1  # [win]
@@ -56,7 +57,7 @@ test:
     - where mpiexec.exe  # [win]
     - where smpd.exe  # [win]
     - mpiexec.exe -d 3 -n 2 Tests\\MpiPingpong.exe -m  # [win]
-    - mpiexec.exe -d 3 -n 2 Tests\\IMB_MPI1.exe PingPong PingPing PingPongAnySource PingPingAnySource Sendrecv Allreduce -off_cache -1 -msglog 10  # [win]
+    - mpiexec.exe -d 3 -n 2 Tests\\IMB-MPI1.exe PingPong PingPing PingPongAnySource PingPingAnySource Sendrecv Allreduce -off_cache -1 -msglog 10  # [win]
 
     # This works! Just comment out to save time...
     ## test compiling + linking + execution


### PR DESCRIPTION
Close #2.

This PR does 3 things:
1. Use Windows installer and install (not extract!) to `$PREFIX\Library`
2. Fix (de)activate scripts to not print debug messages in user environments 
3. Erase the pre-installed MPI from Conda-Forge's VM image so that downstream packages can test MPI against `msmpi`

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
